### PR TITLE
chore: onboarding docs + cross-platform lint/line-ending fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize line endings: store LF in the repo, check out native.
+# Fixes cross-platform diffs and makes prettier (LF) consistent on Windows.
+* text=auto eol=lf
+
+# Binary assets — never normalized.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.woff binary
+*.woff2 binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to JobMatch
+
+Thanks for your interest! JobMatch is a full-stack job-matching platform
+(Next.js + NestJS + PostgreSQL). This guide gets you from clone to a
+running stack and a green test suite.
+
+## Prerequisites
+
+- Docker + Docker Compose (the supported way to run everything)
+- Node.js 20+ and npm (only if you run an app outside Docker)
+
+## Run the stack
+
+```sh
+git clone https://github.com/AchrafReyani/job-matching-platform.git
+cd job-matching-platform
+docker compose up --build
+```
+
+- Frontend: http://localhost:3000
+- Backend (Swagger): http://localhost:3001/api-docs
+- Postgres: localhost:5432 (`dev` / `devpass`)
+
+Apply migrations and seed demo data:
+
+```sh
+docker exec job_matching_backend npx prisma migrate deploy
+docker exec job_matching_backend npx prisma db seed
+```
+
+Seed accounts (password `password123`, admin `admin123`):
+
+| Role       | Email                                 |
+|------------|---------------------------------------|
+| Job seeker | charlie@example.com, bob@example.com  |
+| Company    | hr@techcorp.com, hr@innovate.io       |
+| Admin      | admin@jobmatch.com                    |
+
+## Project layout
+
+```
+apps/backend    NestJS API — clean architecture: Controller → Use Case → Repository → Prisma
+apps/frontend   Next.js 15 (App Router), next-intl (EN + NL), Tailwind
+```
+
+## Tests, lint, types (run before every PR)
+
+Run these on the **host** (not `docker exec`) so tooling picks up
+`apps/backend/.prettierrc`:
+
+```sh
+# Backend
+cd apps/backend
+npm test                 # unit tests
+npm run test:e2e         # end-to-end (needs the db container up)
+npx tsc --noEmit         # types
+npm run lint             # eslint + prettier
+
+# Frontend
+cd apps/frontend
+npm test
+npx tsc --noEmit
+npm run lint
+```
+
+## Conventions
+
+- **Clean architecture** on the backend: a controller calls a use case,
+  which calls a repository interface, implemented by a Prisma repository.
+  Each use case has a `*.usecase.spec.ts`; endpoints have e2e tests.
+- **No hardcoded UI text** — use `next-intl` and add keys to both
+  `apps/frontend/messages/en.json` and `nl.json`.
+- **Quotes/formatting**: prettier enforces single quotes + LF (see
+  `.prettierrc` / `.editorconfig`). `.gitattributes` normalizes line
+  endings, so Windows contributors get clean diffs.
+- **Commits**: conventional commits (`feat:`, `fix:`, `test:`, `chore:`).
+  Branches: `feature/<short-name>` or `fix/<short-name>`.
+- When changing `schema.prisma`, generate a migration:
+  `docker exec job_matching_backend npx prisma migrate dev --name <change>`.
+
+## Prisma in Docker
+
+```sh
+docker exec job_matching_backend npx prisma migrate dev --name <change>
+docker exec job_matching_backend npx prisma generate
+```
+
+## Optional: LINE login (renkei)
+
+The backend can offer "Continue with LINE" via
+[renkei](https://github.com/AchrafReyani/renkei), a self-hosted OIDC
+broker for LINE. It's off unless `RENKEI_ISSUER`, `RENKEI_CLIENT_ID`,
+`RENKEI_CLIENT_SECRET` and `BACKEND_URL` are set (see
+`apps/backend/.env.example`). You do **not** need it to work on the rest
+of the app.
+
+## Good first issues
+
+Look for the [`good first issue`](https://github.com/AchrafReyani/job-matching-platform/labels/good%20first%20issue)
+label. Questions are welcome in an issue or on a draft PR.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ be found in the `/docs` folder.
 
 ------------------------------------------------------------------------
 
+## 🤝 Contributing
+
+Contributions are welcome! See **[CONTRIBUTING.md](CONTRIBUTING.md)** for a
+one-command local setup (`docker compose up`), the test/lint commands, and
+project conventions. Good first issues are labelled
+[`good first issue`](https://github.com/AchrafReyani/job-matching-platform/labels/good%20first%20issue).
+
+Optional: the backend can offer **"Continue with LINE"** via
+[renkei](https://github.com/AchrafReyani/renkei) (a self-hosted OIDC broker
+for LINE Login). It stays disabled unless the `RENKEI_*` env vars are set —
+see `apps/backend/.env.example`.
+
+------------------------------------------------------------------------
+
 ## 📜 License
 
 Licensed under the **Apache-2.0 License**.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,0 +1,18 @@
+# JobMatch backend (NestJS) — copy to .env for local runs outside Docker.
+# With `docker compose up` these are set in docker-compose.yml instead.
+
+# Required
+DATABASE_URL=postgresql://dev:devpass@localhost:5432/jobmatching
+JWT_SECRET=change-me-in-production
+PORT=3001
+FRONTEND_URL=http://localhost:3000
+
+# Optional: LINE login via renkei (https://github.com/AchrafReyani/renkei).
+# Leave all four unset to disable LINE login (the endpoints return 503).
+# BACKEND_URL is this API's own public URL; the OIDC callback is
+# <BACKEND_URL>/auth/line/callback and must be registered as a redirect URI
+# on the renkei client (RENKEI_CLIENTS on the renkei side).
+# RENKEI_ISSUER=https://renkei-demo.onrender.com
+# RENKEI_CLIENT_ID=jobmatch
+# RENKEI_CLIENT_SECRET=your-renkei-client-secret
+# BACKEND_URL=http://localhost:3001

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,5 @@
+# JobMatch frontend (Next.js) — copy to .env.local for local runs outside Docker.
+# With `docker compose up` this is set in docker-compose.yml instead.
+
+# Base URL of the backend API.
+NEXT_PUBLIC_API_URL=http://localhost:3001

--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - ./apps/backend/test:/app/test
       - ./apps/backend/tsconfig.json:/app/tsconfig.json
       - ./apps/backend/eslint.config.mjs:/app/eslint.config.mjs
+      - ./apps/backend/.prettierrc:/app/.prettierrc
       # Prevent overwriting node_modules from container
       - /app/node_modules
     depends_on:


### PR DESCRIPTION
Makes the repo easier for others to clone, run, and contribute to — no product behavior changes.

## What's here
- **CONTRIBUTING.md** — one-command Docker setup (`docker compose up`), migrate + seed, seed accounts, the backend clean-architecture layout, the exact test/lint/type commands, commit/branch conventions, and Prisma-in-Docker notes.
- **.env.example** for backend and frontend documenting every env var (incl. the optional renkei LINE-login vars). Frontend `.gitignore` now keeps `.env.example` tracked.
- **.gitattributes (`eol=lf`) + .editorconfig** — ends the CRLF-vs-LF churn so Windows contributors get clean diffs and prettier (single-quote + LF) is consistent.
- **docker-compose** — mounts `apps/backend/.prettierrc` into the backend container so `npm run lint` there no longer reformats the whole tree to double quotes.
- **README** — a Contributing section + a note on the optional LINE login.

## Note on line endings
`.gitattributes` normalizes to LF going forward. Existing files aren't rewritten by this PR; a maintainer can run `git add --renormalize .` in a separate commit if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)