### PR TITLE
feat(frontend): add loading skeletons for dashboard stat cards (#11)

### DIFF
--- a/apps/frontend/app/dashboard/admin/page.tsx
+++ b/apps/frontend/app/dashboard/admin/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { StatCard } from '@/components/dashboard/StatCard';
+import { AdminStatsGridSkeleton } from '@/components/dashboard/StatsGrid';
 import { getAdminStats } from '@/lib/admin/api';
 import { AdminStats } from '@/lib/admin/types';
 import Link from 'next/link';
@@ -76,19 +77,13 @@ export default function AdminDashboardPage() {
           </p>
         </div>
 
-        {loading && (
-          <div className="text-center py-8">
-            <p className="text-[var(--color-text)]">{t('loadingStats')}</p>
-          </div>
-        )}
-
-        {error && (
+        {loading ? (
+          <AdminStatsGridSkeleton />
+        ) : error ? (
           <div className="bg-red-100 text-red-700 p-4 rounded-lg">
             {error}
           </div>
-        )}
-
-        {stats && (
+        ) : stats ? (
           <>
             {/* Main Stats */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -174,7 +169,7 @@ export default function AdminDashboardPage() {
               </Link>
             </div>
           </>
-        )}
+        ) : null}
       </div>
     </DashboardLayout>
   );

--- a/apps/frontend/app/dashboard/company/page.tsx
+++ b/apps/frontend/app/dashboard/company/page.tsx
@@ -3,12 +3,11 @@
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
-import { CompanyStatsGrid } from '@/components/dashboard/StatsGrid';
+import { CompanyStatsGrid, CompanyStatsGridSkeleton } from '@/components/dashboard/StatsGrid';
 import { NotificationList } from '@/components/notifications/NotificationList';
 import { getDashboardStats } from '@/lib/dashboard/api';
 import { CompanyStats } from '@/lib/dashboard/types';
 import { Card } from '@/components/ui/Card';
-import { LoadingContainer } from '@/components/ui/LoadingSpinner';
 
 export default function CompanyDashboard() {
   const t = useTranslations('Dashboard.company');
@@ -43,7 +42,7 @@ export default function CompanyDashboard() {
 
         {/* Stats Section */}
         {loading ? (
-          <LoadingContainer />
+          <CompanyStatsGridSkeleton />
         ) : error ? (
           <div className="text-center py-8 text-red-500">{error}</div>
         ) : stats ? (

--- a/apps/frontend/app/dashboard/job-seeker/page.tsx
+++ b/apps/frontend/app/dashboard/job-seeker/page.tsx
@@ -3,12 +3,11 @@
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
-import { JobSeekerStatsGrid } from '@/components/dashboard/StatsGrid';
+import { JobSeekerStatsGrid, JobSeekerStatsGridSkeleton } from '@/components/dashboard/StatsGrid';
 import { NotificationList } from '@/components/notifications/NotificationList';
 import { getDashboardStats } from '@/lib/dashboard/api';
 import { JobSeekerStats } from '@/lib/dashboard/types';
 import { Card } from '@/components/ui/Card';
-import { LoadingContainer } from '@/components/ui/LoadingSpinner';
 
 export default function JobSeekerDashboard() {
   const t = useTranslations('Dashboard.jobSeeker');
@@ -43,7 +42,7 @@ export default function JobSeekerDashboard() {
 
         {/* Stats Section */}
         {loading ? (
-          <LoadingContainer />
+          <JobSeekerStatsGridSkeleton />
         ) : error ? (
           <div className="text-center py-8 text-red-500">{error}</div>
         ) : stats ? (

--- a/apps/frontend/components/dashboard/StatCard.tsx
+++ b/apps/frontend/components/dashboard/StatCard.tsx
@@ -3,13 +3,41 @@
 import { ReactNode } from 'react';
 
 interface StatCardProps {
-  title: string;
-  value: number | string;
+  title?: string;
+  value?: number | string;
   icon?: ReactNode;
   variant?: 'default' | 'success' | 'warning' | 'danger';
+  loading?: boolean;
 }
 
-export function StatCard({ title, value, icon, variant = 'default' }: StatCardProps) {
+export function StatCardSkeleton() {
+  return (
+    <div
+      data-testid="stat-card-skeleton"
+      className="bg-[var(--color-bg)] rounded-xl p-6 border-l-4 border-[var(--color-secondary)] shadow-sm animate-pulse"
+    >
+      <div className="flex items-center justify-between">
+        <div className="space-y-2 flex-1">
+          <div className="h-4 w-24 bg-[var(--color-secondary)] rounded" />
+          <div className="h-8 w-16 bg-[var(--color-secondary)] rounded mt-1" />
+        </div>
+        <div className="w-12 h-12 rounded-lg bg-[var(--color-secondary)] flex-shrink-0" />
+      </div>
+    </div>
+  );
+}
+
+export function StatCard({
+  title,
+  value,
+  icon,
+  variant = 'default',
+  loading = false,
+}: StatCardProps) {
+  if (loading) {
+    return <StatCardSkeleton />;
+  }
+
   const variantStyles = {
     default: 'border-[var(--color-secondary)]',
     success: 'border-green-500',
@@ -26,6 +54,7 @@ export function StatCard({ title, value, icon, variant = 'default' }: StatCardPr
 
   return (
     <div
+      data-testid="stat-card"
       className={`
         bg-[var(--color-bg)] rounded-xl p-6 border-l-4 shadow-sm
         ${variantStyles[variant]}

--- a/apps/frontend/components/dashboard/StatsGrid.tsx
+++ b/apps/frontend/components/dashboard/StatsGrid.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import { StatCard } from './StatCard';
+import { StatCard, StatCardSkeleton } from './StatCard';
 import { JobSeekerStats, CompanyStats } from '@/lib/dashboard/types';
 
 interface JobSeekerStatsGridProps {
-  stats: JobSeekerStats;
+  stats?: JobSeekerStats;
+  loading?: boolean;
 }
 
 interface CompanyStatsGridProps {
-  stats: CompanyStats;
+  stats?: CompanyStats;
+  loading?: boolean;
 }
 
 // Icons
@@ -54,7 +56,54 @@ const NewIcon = () => (
   </svg>
 );
 
-export function JobSeekerStatsGrid({ stats }: JobSeekerStatsGridProps) {
+export function JobSeekerStatsGridSkeleton() {
+  return (
+    <div data-testid="job-seeker-stats-skeleton" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+    </div>
+  );
+}
+
+export function CompanyStatsGridSkeleton() {
+  return (
+    <div data-testid="company-stats-skeleton" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+      <StatCardSkeleton />
+    </div>
+  );
+}
+
+export function AdminStatsGridSkeleton() {
+  return (
+    <div data-testid="admin-stats-skeleton" className="space-y-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <StatCardSkeleton />
+        <StatCardSkeleton />
+        <StatCardSkeleton />
+        <StatCardSkeleton />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <StatCardSkeleton />
+        <StatCardSkeleton />
+        <StatCardSkeleton />
+        <StatCardSkeleton />
+      </div>
+    </div>
+  );
+}
+
+export function JobSeekerStatsGrid({ stats, loading = false }: JobSeekerStatsGridProps) {
+  if (loading || !stats) {
+    return <JobSeekerStatsGridSkeleton />;
+  }
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       <StatCard
@@ -85,7 +134,11 @@ export function JobSeekerStatsGrid({ stats }: JobSeekerStatsGridProps) {
   );
 }
 
-export function CompanyStatsGrid({ stats }: CompanyStatsGridProps) {
+export function CompanyStatsGrid({ stats, loading = false }: CompanyStatsGridProps) {
+  if (loading || !stats) {
+    return <CompanyStatsGridSkeleton />;
+  }
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       <StatCard


### PR DESCRIPTION
## Summary
Resolves [#11](https://github.com/AchrafReyani/job-matching-platform/issues/11) by adding animated loading skeleton placeholders for stat cards across the **Job Seeker**, **Company**, and **Admin** dashboards. This prevents content pop-in and provides a smooth loading experience.

## Key Changes

### Frontend Components
- **`StatCard.tsx`**: Added `StatCardSkeleton` component with pulse animation (`animate-pulse`) styled to match `StatCard` layout using `--color-secondary` and `--color-bg` CSS theme variables. Added optional `loading` prop support.
- **`StatsGrid.tsx`**: Exported `JobSeekerStatsGridSkeleton` (4 cards), `CompanyStatsGridSkeleton` (6 cards), and `AdminStatsGridSkeleton` (8 cards across main and activity sections).

### Dashboard Pages
- **Job Seeker Dashboard (`app/dashboard/job-seeker/page.tsx`)**: Replaced generic loading spinner with `JobSeekerStatsGridSkeleton`.
- **Company Dashboard (`app/dashboard/company/page.tsx`)**: Replaced generic loading spinner with `CompanyStatsGridSkeleton`.
- **Admin Dashboard (`app/dashboard/admin/page.tsx`)**: Replaced loading text indicator with `AdminStatsGridSkeleton`.

## Verification
- Ran unit tests across all frontend suites (`npm test`) — all 9 test suites passing.
- Verified visual alignment and theme variable compatibility (light & dark modes) for skeleton placeholders.