### PR TITLE
feat(backend): add per-request HTTP logging middleware (#29)

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { PrismaService } from './prisma.service';
 import { AuthModule } from './auth/auth.module';
@@ -13,6 +13,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { AdminModule } from './admin/admin.module';
 import { NewsModule } from './news/news.module';
+import { LoggingMiddleware } from './common/middleware/logging.middleware';
 
 import { AppController } from './app.controller';
 
@@ -36,4 +37,10 @@ import { AppController } from './app.controller';
   providers: [PrismaService],
   exports: [PrismaService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    if (process.env.NODE_ENV !== 'test') {
+      consumer.apply(LoggingMiddleware).forRoutes('*');
+    }
+  }
+}

--- a/apps/backend/src/common/middleware/logging.middleware.spec.ts
+++ b/apps/backend/src/common/middleware/logging.middleware.spec.ts
@@ -1,0 +1,99 @@
+import { Logger } from '@nestjs/common';
+import type { Request, Response, NextFunction } from 'express';
+import { EventEmitter } from 'events';
+import { LoggingMiddleware } from './logging.middleware';
+
+describe('LoggingMiddleware', () => {
+  let middleware: LoggingMiddleware;
+  let loggerSpy: jest.SpyInstance;
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    middleware = new LoggingMiddleware();
+    loggerSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(middleware).toBeDefined();
+  });
+
+  it('should call next() and not log when NODE_ENV is test', () => {
+    process.env.NODE_ENV = 'test';
+
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/vacancies',
+    } as Request;
+
+    const res = new EventEmitter() as unknown as Response;
+    const next: NextFunction = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+
+    // Emit finish event to verify no logging occurs
+    res.emit('finish');
+    expect(loggerSpy).not.toHaveBeenCalled();
+  });
+
+  it('should log request method, originalUrl, status code, and duration on finish in non-test env', () => {
+    process.env.NODE_ENV = 'development';
+
+    const req = {
+      method: 'POST',
+      originalUrl: '/auth/login',
+    } as Request;
+
+    const res = new EventEmitter() as unknown as Response & {
+      statusCode: number;
+    };
+    res.statusCode = 200;
+
+    const next: NextFunction = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+
+    // Emit finish event
+    res.emit('finish');
+
+    expect(loggerSpy).toHaveBeenCalledTimes(1);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/^POST \/auth\/login 200 \+\d+ms$/),
+    );
+  });
+
+  it('should fallback to req.url if req.originalUrl is not present', () => {
+    process.env.NODE_ENV = 'production';
+
+    const req = {
+      method: 'GET',
+      url: '/health',
+    } as Request;
+
+    const res = new EventEmitter() as unknown as Response & {
+      statusCode: number;
+    };
+    res.statusCode = 200;
+
+    const next: NextFunction = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+
+    res.emit('finish');
+
+    expect(loggerSpy).toHaveBeenCalledTimes(1);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/^GET \/health 200 \+\d+ms$/),
+    );
+  });
+});

--- a/apps/backend/src/common/middleware/logging.middleware.ts
+++ b/apps/backend/src/common/middleware/logging.middleware.ts
@@ -1,0 +1,25 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import type { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class LoggingMiddleware implements NestMiddleware {
+  private readonly logger = new Logger('HTTP');
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    if (process.env.NODE_ENV === 'test') {
+      return next();
+    }
+
+    const { method, originalUrl, url } = req;
+    const path = originalUrl || url;
+    const startTime = Date.now();
+
+    res.on('finish', () => {
+      const { statusCode } = res;
+      const duration = Date.now() - startTime;
+      this.logger.log(`${method} ${path} ${statusCode} +${duration}ms`);
+    });
+
+    next();
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for contributing! 🎉
  Please fill in all sections below before requesting a review.
  PRs that are missing required information may be closed without review.
  Reference: CONTRIBUTING.md
-->

# 📋 Summary

Adds a custom NestJS middleware to provide concise, per-request HTTP logging for the backend. This produces structured log entries (e.g., `[HTTP] GET /api/vacancies 200 +15ms`) to make debugging in Render and Docker much easier, while specifically excluding the test environment to keep test outputs clean.

## 🏷️ Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [ ] 📚 Documentation
- [x] 🧹 Chore

## 🔗 Related Issue

Closes #29 

## 🛠️ Changes Made

### Backend (`apps/backend`)

- Added `LoggingMiddleware` using NestJS's built-in `Logger` to log method, path, status code, and duration on response finish.
- Configured `AppModule` to apply the middleware globally for all routes.
- Added environment guards so the middleware is completely bypassed and not registered when `NODE_ENV=test`.
- Added comprehensive unit tests in `logging.middleware.spec.ts`.

## ⚙️ Configuration & Migrations
- [ ] This PR requires new **environment variables** (I have updated `.env.example` and documented them).
- [ ] This PR includes **database migrations** (I have verified them locally).
- [x] N/A — No new environment variables or migrations.

## 🧪 Testing

**How was this tested?**

- [x] Unit tests
- [ ] Integration / E2E tests
- [x] Manual testing (describe steps below)

**Manual testing steps (if applicable):**

1. Verified unit tests pass via `npm test`.
```
PASS  src/common/middleware/logging.middleware.spec.ts
  LoggingMiddleware
    ✓ should be defined (3 ms)
    ✓ should call next() and not log when NODE_ENV is test (1 ms)
    ✓ should log request method, originalUrl, status code, and duration on finish in non-test env (3 ms)
    ✓ should fallback to req.url if req.originalUrl is not present (2 ms)
```
2. Started the backend locally and made requests via the browser/swagger.
3. Verified the console outputs the correct log format and doesn't pollute the test runner output.
```
2026-08-30 13:13:33.916 | 
2026-08-30 13:13:33.916 | > backend@0.0.1 start:dev
2026-08-30 13:13:33.916 | > nest start --watch
2026-08-30 13:13:33.916 | 
2026-08-30 13:13:37.341 | [7:43:37 AM] Starting compilation in watch mode...
2026-08-30 13:13:37.341 | 
2026-08-30 13:13:52.596 | [7:43:52 AM] Found 0 errors. Watching for file changes.
2026-08-30 13:13:52.596 | 
2026-08-30 13:13:55.094 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [NestFactory] Starting Nest application...
2026-08-30 13:13:55.149 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [LineOidcService] LINE login disabled (RENKEI_ISSUER / RENKEI_CLIENT_ID / RENKEI_CLIENT_SECRET not set)
2026-08-30 13:13:55.161 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] PrismaModule dependencies initialized +11ms
2026-08-30 13:13:55.166 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] JwtModule dependencies initialized +5ms
2026-08-30 13:13:55.166 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] ThrottlerModule dependencies initialized +1ms
2026-08-30 13:13:55.166 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] AppModule dependencies initialized +0ms
2026-08-30 13:13:55.167 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] DiscoveryModule dependencies initialized +0ms
2026-08-30 13:13:55.171 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] ScheduleModule dependencies initialized +5ms
2026-08-30 13:13:55.173 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] AuthModule dependencies initialized +2ms
2026-08-30 13:13:55.175 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] CompaniesModule dependencies initialized +2ms
2026-08-30 13:13:55.176 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] UserManagementModule dependencies initialized +0ms
2026-08-30 13:13:55.176 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] UsersModule dependencies initialized +0ms
2026-08-30 13:13:55.176 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] VacancyModule dependencies initialized +1ms
2026-08-30 13:13:55.176 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] NotificationsModule dependencies initialized +0ms
2026-08-30 13:13:55.176 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] ProfilesModule dependencies initialized +0ms
2026-08-30 13:13:55.176 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] DashboardModule dependencies initialized +0ms
2026-08-30 13:13:55.176 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] ApplicationsModule dependencies initialized +0ms
2026-08-30 13:13:55.177 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] MessagesModule dependencies initialized +0ms
2026-08-30 13:13:55.177 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] AdminModule dependencies initialized +0ms
2026-08-30 13:13:55.177 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [InstanceLoader] NewsModule dependencies initialized +1ms
2026-08-30 13:13:55.278 | [Nest] 52  - 08/30/2026, 7:43:55 AM   ERROR Duplicate DTO detected: "UpdateVacancyDto" is defined multiple times with different schemas.
2026-08-30 13:13:55.278 | Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.
2026-08-30 13:13:55.278 | Note: This will throw an error in the next major version.
2026-08-30 13:13:55.337 | Swagger enabled at /api-docs
2026-08-30 13:13:55.354 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] AppController {/}: +75ms
2026-08-30 13:13:55.365 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/, GET} route +11ms
2026-08-30 13:13:55.366 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] AuthController {/auth}: +1ms
2026-08-30 13:13:55.367 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/auth/login, POST} route +2ms
2026-08-30 13:13:55.367 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] LineAuthController {/auth/line}: +0ms
2026-08-30 13:13:55.368 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/auth/line/start, GET} route +1ms
2026-08-30 13:13:55.369 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/auth/line/callback, GET} route +0ms
2026-08-30 13:13:55.369 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] UserManagementController {/auth}: +0ms
2026-08-30 13:13:55.370 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/auth/register/job-seeker, POST} route +1ms
2026-08-30 13:13:55.370 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/auth/register/company, POST} route +1ms
2026-08-30 13:13:55.372 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/auth/profile, GET} route +1ms
2026-08-30 13:13:55.373 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/auth/profile, PUT} route +1ms
2026-08-30 13:13:55.373 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] AccountController {/users/me}: +0ms
2026-08-30 13:13:55.382 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/users/me/password, PATCH} route +9ms
2026-08-30 13:13:55.384 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/users/me/notification-preferences, GET} route +2ms
2026-08-30 13:13:55.385 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/users/me/notification-preferences, PATCH} route +1ms
2026-08-30 13:13:55.387 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/users/me/delete, POST} route +2ms
2026-08-30 13:13:55.387 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] VacancyController {/vacancies}: +1ms
2026-08-30 13:13:55.389 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/vacancies, GET} route +1ms
2026-08-30 13:13:55.396 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/vacancies/:id, GET} route +8ms
2026-08-30 13:13:55.399 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/vacancies/company/:companyId, GET} route +3ms
2026-08-30 13:13:55.400 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/vacancies, POST} route +0ms
2026-08-30 13:13:55.400 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/vacancies/:id, PATCH} route +1ms
2026-08-30 13:13:55.401 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/vacancies/:id, DELETE} route +1ms
2026-08-30 13:13:55.401 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] CompaniesController {/companies}: +0ms
2026-08-30 13:13:55.402 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/companies/:id, GET} route +0ms
2026-08-30 13:13:55.403 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/companies/:id/profile, GET} route +1ms
2026-08-30 13:13:55.404 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/companies, GET} route +1ms
2026-08-30 13:13:55.404 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] ApplicationsController {/applications}: +1ms
2026-08-30 13:13:55.405 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/applications/details/:id, GET} route +1ms
2026-08-30 13:13:55.406 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/applications, POST} route +1ms
2026-08-30 13:13:55.409 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/applications/me, GET} route +3ms
2026-08-30 13:13:55.412 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/applications/company, GET} route +1ms
2026-08-30 13:13:55.414 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/applications/:id, PATCH} route +3ms
2026-08-30 13:13:55.416 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/applications/:id/match, DELETE} route +2ms
2026-08-30 13:13:55.416 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] NotificationsController {/notifications}: +1ms
2026-08-30 13:13:55.417 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/notifications, GET} route +0ms
2026-08-30 13:13:55.417 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/notifications/unread-count, GET} route +1ms
2026-08-30 13:13:55.418 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/notifications/:id/read, PATCH} route +0ms
2026-08-30 13:13:55.418 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/notifications/read-all, PATCH} route +1ms
2026-08-30 13:13:55.418 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] MessagesController {/messages}: +0ms
2026-08-30 13:13:55.419 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/messages, POST} route +1ms
2026-08-30 13:13:55.419 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/messages/conversations, GET} route +0ms
2026-08-30 13:13:55.420 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/messages/:applicationId, GET} route +0ms
2026-08-30 13:13:55.420 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/messages/:applicationId/read, PATCH} route +1ms
2026-08-30 13:13:55.420 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] ProfilesController {/profiles}: +0ms
2026-08-30 13:13:55.421 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/profiles/:id, GET} route +0ms
2026-08-30 13:13:55.421 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] DashboardController {/dashboard}: +1ms
2026-08-30 13:13:55.421 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/dashboard/stats, GET} route +0ms
2026-08-30 13:13:55.421 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] AdminController {/admin}: +0ms
2026-08-30 13:13:55.422 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/stats, GET} route +1ms
2026-08-30 13:13:55.422 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/users, GET} route +0ms
2026-08-30 13:13:55.423 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/users/:id, GET} route +0ms
2026-08-30 13:13:55.432 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/users/:id, PATCH} route +10ms
2026-08-30 13:13:55.433 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/users/:id, DELETE} route +1ms
2026-08-30 13:13:55.434 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/users/bulk/job-seekers, DELETE} route +0ms
2026-08-30 13:13:55.435 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/users/bulk/companies, DELETE} route +1ms
2026-08-30 13:13:55.435 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/vacancies, GET} route +1ms
2026-08-30 13:13:55.437 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/vacancies/:id, GET} route +1ms
2026-08-30 13:13:55.438 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/vacancies/:id, PATCH} route +1ms
2026-08-30 13:13:55.439 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/vacancies/:id, DELETE} route +1ms
2026-08-30 13:13:55.439 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/admin/vacancies/bulk/all, DELETE} route +1ms
2026-08-30 13:13:55.439 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RoutesResolver] NewsController {/news}: +0ms
2026-08-30 13:13:55.440 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news/admin, GET} route +1ms
2026-08-30 13:13:55.441 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news/admin/:id, GET} route +1ms
2026-08-30 13:13:55.442 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news, POST} route +0ms
2026-08-30 13:13:55.442 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news/:id, PATCH} route +1ms
2026-08-30 13:13:55.443 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news/:id, DELETE} route +1ms
2026-08-30 13:13:55.444 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news/:id/publish, POST} route +0ms
2026-08-30 13:13:55.445 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news, GET} route +1ms
2026-08-30 13:13:55.445 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news/unread-count, GET} route +1ms
2026-08-30 13:13:55.455 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news/:id, GET} route +9ms
2026-08-30 13:13:55.456 | [Nest] 52  - 08/30/2026, 7:43:55 AM     LOG [RouterExplorer] Mapped {/news/:id/read, POST} route +2ms
2026-08-30 13:13:58.005 | [Nest] 52  - 08/30/2026, 7:43:58 AM     LOG [NestApplication] Nest application successfully started +2547ms
2026-08-30 13:13:58.012 | Nest app listening on port 3001
2026-08-30 13:15:00.096 | [Nest] 52  - 08/30/2026, 7:45:00 AM     LOG [PublishScheduledNewsUseCase] Published 1 scheduled news posts: 26
2026-08-30 13:15:10.896 | [Nest] 52  - 08/30/2026, 7:45:10 AM     LOG [HTTP] POST /auth/login 401 +47ms
2026-08-30 13:15:18.088 | [Nest] 52  - 08/30/2026, 7:45:18 AM     LOG [HTTP] POST /auth/login 401 +5ms
2026-08-30 13:15:18.255 | [Nest] 52  - 08/30/2026, 7:45:18 AM     LOG [HTTP] POST /auth/login 401 +9ms
2026-08-30 13:15:18.475 | [Nest] 52  - 08/30/2026, 7:45:18 AM     LOG [HTTP] POST /auth/login 401 +9ms
2026-08-30 13:15:18.598 | [Nest] 52  - 08/30/2026, 7:45:18 AM     LOG [HTTP] POST /auth/login 401 +4ms
2026-08-30 13:15:18.793 | [Nest] 52  - 08/30/2026, 7:45:18 AM     LOG [HTTP] POST /auth/login 401 +4ms
2026-08-30 13:15:18.931 | [Nest] 52  - 08/30/2026, 7:45:18 AM     LOG [HTTP] POST /auth/login 401 +5ms
2026-08-30 13:16:04.156 | [Nest] 52  - 08/30/2026, 7:46:04 AM     LOG [HTTP] GET /auth/line/start 503 +15ms
2026-08-30 13:16:05.470 | [Nest] 52  - 08/30/2026, 7:46:05 AM     LOG [HTTP] GET /auth/line/start 503 +2ms
2026-08-30 13:16:08.320 | [Nest] 52  - 08/30/2026, 7:46:08 AM     LOG [HTTP] GET /auth/line/start 503 +1ms
2026-08-30 13:16:08.486 | [Nest] 52  - 08/30/2026, 7:46:08 AM     LOG [HTTP] GET /auth/line/start 503 +1ms
2026-08-30 13:16:08.672 | [Nest] 52  - 08/30/2026, 7:46:08 AM     LOG [HTTP] GET /auth/line/start 503 +1ms
2026-08-30 13:16:08.838 | [Nest] 52  - 08/30/2026, 7:46:08 AM     LOG [HTTP] GET /auth/line/start 503 +1ms
2026-08-30 13:16:09.056 | [Nest] 52  - 08/30/2026, 7:46:09 AM     LOG [HTTP] GET /auth/line/start 503 +1ms
2026-08-30 13:16:20.014 | [Nest] 52  - 08/30/2026, 7:46:20 AM     LOG [HTTP] GET / 304 +14ms
2026-08-30 13:16:22.870 | [Nest] 52  - 08/30/2026, 7:46:22 AM     LOG [HTTP] GET / 304 +1ms
```

## ✅ Contributor Checklist

- [x] I have read and followed [CONTRIBUTING.md](https://github.com/AchrafReyani/job-matching-platform/blob/main/CONTRIBUTING.md).
- [x] **Lint and tests pass** locally in every package I touched (`npm run lint` and `npm test` in `apps/frontend` and/or `apps/backend` — see [CONTRIBUTING.md](https://github.com/AchrafReyani/job-matching-platform/blob/main/CONTRIBUTING.md#tests-lint-types-run-before-every-pr)).
- [x] I have performed a **self-review** of my own code.
- [x] My changes are **scoped to this issue** — no unrelated changes are included.
- [x] **Documentation** has been updated if my changes affect public APIs, config, or user-facing behavior.
- [ ] **Screenshots** are included for any UI changes (see section above).
- [x] The related **issue is linked** with a closing keyword (e.g. `Closes #123`)