### PR TITLE
feat(auth): add rate limiting to login endpoint (#26)

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,5 +1,6 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { PrismaService } from './prisma.service';
 import { AuthModule } from './auth/auth.module';
 import { UserManagementModule } from './user-management/user-management.module';
@@ -20,6 +21,12 @@ import { AppController } from './app.controller';
 @Module({
   imports: [
     ScheduleModule.forRoot(),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000, // 1 minute
+        limit: 10, // 10 requests per minute default
+      },
+    ]),
     AuthModule,
     UserManagementModule,
     UsersModule,

--- a/apps/backend/src/auth/controller/auth.controller.spec.ts
+++ b/apps/backend/src/auth/controller/auth.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
 import { LoginUseCase } from '../usecase/login.usecase';
+import { ThrottlerModule } from '@nestjs/throttler';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -8,6 +9,14 @@ describe('AuthController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot([
+          {
+            ttl: 60000,
+            limit: 10,
+          },
+        ]),
+      ],
       controllers: [AuthController],
       providers: [{ provide: LoginUseCase, useValue: mockLoginUseCase }],
     }).compile();

--- a/apps/backend/src/auth/controller/auth.controller.ts
+++ b/apps/backend/src/auth/controller/auth.controller.ts
@@ -1,12 +1,15 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { LoginDto } from '../dto/login.dto';
 import { LoginUseCase } from '../usecase/login.usecase';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 
 @Controller('auth')
+@UseGuards(ThrottlerGuard)
 export class AuthController {
   constructor(private readonly loginUseCase: LoginUseCase) {}
 
   @Post('login')
+  @Throttle({ default: { limit: 5, ttl: 60000 } }) // 5 attempts per minute
   login(@Body() dto: LoginDto) {
     return this.loginUseCase.execute(dto);
   }

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -2,9 +2,12 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { NestExpressApplication } from '@nestjs/platform-express';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  app.set('trust proxy', 1);
 
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
 

--- a/apps/backend/src/users/users.module.ts
+++ b/apps/backend/src/users/users.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { ThrottlerModule } from '@nestjs/throttler';
 import { PrismaUserRepository } from './infrastructure/prisma-user.repository';
 import { PrismaService } from '../prisma/prisma.service';
 import { USER_REPOSITORY } from './repository/user.repository';
@@ -13,14 +12,6 @@ import { DeleteAccountUseCase } from './usecase/delete-account.usecase';
 import { AccountController } from './controller/account.controller';
 
 @Module({
-  imports: [
-    ThrottlerModule.forRoot([
-      {
-        ttl: 60000, // 1 minute
-        limit: 10, // 10 requests per minute default
-      },
-    ]),
-  ],
   controllers: [AccountController],
   providers: [
     PrismaService,

--- a/apps/backend/test/auth-throttle.e2e-spec.ts
+++ b/apps/backend/test/auth-throttle.e2e-spec.ts
@@ -1,10 +1,9 @@
-import { Test, TestingModule } from "@nestjs/testing";
-import { INestApplication, ValidationPipe } from "@nestjs/common";
-import { AppModule } from "../src/app.module";
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { AppModule } from '../src/app.module';
+import request from 'supertest';
 
-const request = require("supertest");
-
-describe("Auth Rate Limiting (e2e)", () => {
+describe('Auth Rate Limiting (e2e)', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
@@ -23,28 +22,28 @@ describe("Auth Rate Limiting (e2e)", () => {
     await app.close();
   });
 
-  describe("POST /auth/login rate limiting", () => {
-    it("should return 429 after 5 login attempts and include Retry-After header", async () => {
+  describe('POST /auth/login rate limiting', () => {
+    it('should return 429 after 5 login attempts and include Retry-After header', async () => {
       const payload = {
-        email: "nonexistent@example.com",
-        password: "WrongPassword123!",
+        email: 'nonexistent@example.com',
+        password: 'WrongPassword123!',
       };
 
       // 5 attempts allowed within the window
       for (let i = 0; i < 5; i++) {
         const res = await request(app.getHttpServer())
-          .post("/auth/login")
+          .post('/auth/login')
           .send(payload);
         expect(res.status).not.toBe(429);
       }
 
       // 6th attempt should be rate limited
       const response = await request(app.getHttpServer())
-        .post("/auth/login")
+        .post('/auth/login')
         .send(payload)
         .expect(429);
 
-      expect(response.headers["retry-after"]).toBeDefined();
+      expect(response.headers['retry-after']).toBeDefined();
     });
   });
 });

--- a/apps/backend/test/auth-throttle.e2e-spec.ts
+++ b/apps/backend/test/auth-throttle.e2e-spec.ts
@@ -31,6 +31,7 @@ describe('Auth Rate Limiting (e2e)', () => {
 
       // 5 attempts allowed within the window
       for (let i = 0; i < 5; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const res = await request(app.getHttpServer())
           .post('/auth/login')
           .send(payload);
@@ -38,6 +39,7 @@ describe('Auth Rate Limiting (e2e)', () => {
       }
 
       // 6th attempt should be rate limited
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       const response = await request(app.getHttpServer())
         .post('/auth/login')
         .send(payload)

--- a/apps/backend/test/auth-throttle.e2e-spec.ts
+++ b/apps/backend/test/auth-throttle.e2e-spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import { AppModule } from "../src/app.module";
+
+const request = require("supertest");
+
+describe("Auth Rate Limiting (e2e)", () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe("POST /auth/login rate limiting", () => {
+    it("should return 429 after 5 login attempts and include Retry-After header", async () => {
+      const payload = {
+        email: "nonexistent@example.com",
+        password: "WrongPassword123!",
+      };
+
+      // 5 attempts allowed within the window
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app.getHttpServer())
+          .post("/auth/login")
+          .send(payload);
+        expect(res.status).not.toBe(429);
+      }
+
+      // 6th attempt should be rate limited
+      const response = await request(app.getHttpServer())
+        .post("/auth/login")
+        .send(payload)
+        .expect(429);
+
+      expect(response.headers["retry-after"]).toBeDefined();
+    });
+  });
+});

--- a/apps/backend/test/auth.e2e-spec.ts
+++ b/apps/backend/test/auth.e2e-spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-require-imports */
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, ValidationPipe } from "@nestjs/common";
+import { ThrottlerGuard } from "@nestjs/throttler";
 import { PrismaService } from "../src/prisma/prisma.service";
 import { AppModule } from "../src/app.module";
 
@@ -16,7 +17,10 @@ describe("Auth (e2e)", () => {
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(


### PR DESCRIPTION
# 📋 Summary

Adds brute-force protection to the `POST /auth/login` endpoint using `@nestjs/throttler`. The login route is now limited to **5 requests per minute per IP**, helping reduce the risk of password guessing and automated login attacks.

## 🏷️ Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [ ] 📚 Documentation
- [ ] 🧹 Chore

## 🔗 Related Issue

Closes #26 

## 🛠️ Changes Made

### Backend (`apps/backend`)

- Added `ThrottlerGuard` to the authentication controller.
- Applied route-level throttling to `POST /auth/login`.
- Configured the login endpoint to allow **5 requests per minute per IP**.

## ⚙️ Configuration & Migrations

- [ ] This PR requires new **environment variables** (I have updated `.env.example` and documented them).
- [ ] This PR includes **database migrations** (I have verified them locally).
- [x] N/A — No new environment variables or migrations.

## 🧪 Testing

**How was this tested?**

- [x] Unit tests
- [ ] Integration / E2E tests
- [x] Manual testing (describe steps below)

**Manual testing steps (if applicable):**

1. Start the backend server.
2. Send multiple requests to `POST /auth/login`.
3. Verify that requests exceeding the configured limit are rejected with HTTP `429 Too Many Requests`.
```
[Nest] 29  - 08/30/2026, 8:57:23 AM     LOG [HTTP] POST /auth/login 401 +21ms
[Nest] 29  - 08/30/2026, 8:57:24 AM     LOG [HTTP] POST /auth/login 401 +4ms
[Nest] 29  - 08/30/2026, 8:57:25 AM     LOG [HTTP] POST /auth/login 401 +4ms
[Nest] 29  - 08/30/2026, 8:57:25 AM     LOG [HTTP] POST /auth/login 401 +3ms
[Nest] 29  - 08/30/2026, 8:57:26 AM     LOG [HTTP] POST /auth/login 401 +19ms
[Nest] 29  - 08/30/2026, 8:57:26 AM     LOG [HTTP] POST /auth/login 429 +1ms
[Nest] 29  - 08/30/2026, 8:57:27 AM     LOG [HTTP] POST /auth/login 429 +0ms
```

## ✅ Contributor Checklist

- [x] I have read and followed [CONTRIBUTING.md](https://github.com/AchrafReyani/job-matching-platform/blob/main/CONTRIBUTING.md).
- [x] **Lint and tests pass** locally in every package I touched (`npm run lint` and `npm test` in `apps/frontend` and/or `apps/backend` — see [CONTRIBUTING.md](https://github.com/AchrafReyani/job-matching-platform/blob/main/CONTRIBUTING.md#tests-lint-types-run-before-every-pr)).
- [x] I have performed a **self-review** of my own code.
- [x] My changes are **scoped to this issue** — no unrelated changes are included.
- [x] **Documentation** has been updated if my changes affect public APIs, config, or user-facing behavior.
- [ ] **Screenshots** are included for any UI changes (see section above).
- [x] The related **issue is linked** with a closing keyword (e.g. `Closes #123`)