### PR TITLE
feat(frontend): use renkei-next's LineLoginButton for the LINE login buttons

### DIFF
--- a/apps/frontend/app/login/__tests__/page.test.tsx
+++ b/apps/frontend/app/login/__tests__/page.test.tsx
@@ -85,12 +85,13 @@ describe("LoginPage", () => {
     expect(screen.getByPlaceholderText("Email")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Password")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+    // The LINE buttons are renkei-next's <LineLoginButton />: real links to the backend start URL.
     expect(
-      screen.getByRole("button", { name: "Continue with LINE as Job Seeker" }),
-    ).toBeInTheDocument();
+      screen.getByRole("link", { name: "Continue with LINE as Job Seeker" }),
+    ).toHaveAttribute("href", "/api/auth/line?role=job-seeker");
     expect(
-      screen.getByRole("button", { name: "Continue with LINE as Company" }),
-    ).toBeInTheDocument();
+      screen.getByRole("link", { name: "Continue with LINE as Company" }),
+    ).toHaveAttribute("href", "/api/auth/line?role=company");
   });
 
   it("shows a LINE error message when redirected back with ?error=line", async () => {
@@ -239,27 +240,16 @@ describe("LoginPage", () => {
     });
   });
 
-  it("calls lineLoginUrl with the job-seeker role when that button is clicked", async () => {
-    const user = userEvent.setup();
-
+  it("builds both LINE login links from lineLoginUrl with the chosen role", () => {
     render(<LoginPage />);
-
-    await user.click(
-      screen.getByRole("button", { name: "Continue with LINE as Job Seeker" }),
-    );
 
     expect(lineLoginUrlMock).toHaveBeenCalledWith("job-seeker");
-  });
-
-  it("calls lineLoginUrl with the company role when that button is clicked", async () => {
-    const user = userEvent.setup();
-
-    render(<LoginPage />);
-
-    await user.click(
-      screen.getByRole("button", { name: "Continue with LINE as Company" }),
-    );
-
     expect(lineLoginUrlMock).toHaveBeenCalledWith("company");
+    expect(
+      screen.getByRole("link", { name: "Continue with LINE as Job Seeker" }),
+    ).toHaveAttribute("href", "/api/auth/line?role=job-seeker");
+    expect(
+      screen.getByRole("link", { name: "Continue with LINE as Company" }),
+    ).toHaveAttribute("href", "/api/auth/line?role=company");
   });
 });

--- a/apps/frontend/app/login/page.tsx
+++ b/apps/frontend/app/login/page.tsx
@@ -4,11 +4,15 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { login, getProfile, lineLoginUrl } from '@/lib/auth/api';
-import type { LineSignupRole } from '@/lib/auth/api';
 import { saveToken, getToken, clearToken } from '@/lib/api';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { LineLoginButton } from 'renkei-next/button';
+
+// LINE's official login button (renkei-next), stretched to the card width with the label centred.
+const LINE_BUTTON_CLASS =
+  'w-full [&_.rk-line-login__label]:flex-1 [&_.rk-line-login__label]:justify-center';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -26,10 +30,6 @@ export default function LoginPage() {
       window.history.replaceState(null, '', window.location.pathname);
     }
   }, [t]);
-
-  const startLineLogin = (role: LineSignupRole) => {
-    window.location.assign(lineLoginUrl(role));
-  };
 
   useEffect(() => {
     const checkExistingSession = async () => {
@@ -127,20 +127,16 @@ export default function LoginPage() {
         </div>
 
         <div className="flex flex-col gap-3" aria-label={t('lineLogin')}>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => startLineLogin('job-seeker')}
-          >
-            {t('lineAsJobSeeker')}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => startLineLogin('company')}
-          >
-            {t('lineAsCompany')}
-          </Button>
+          <LineLoginButton
+            href={lineLoginUrl('job-seeker')}
+            label={t('lineAsJobSeeker')}
+            className={LINE_BUTTON_CLASS}
+          />
+          <LineLoginButton
+            href={lineLoginUrl('company')}
+            label={t('lineAsCompany')}
+            className={LINE_BUTTON_CLASS}
+          />
           <p className="text-xs text-center text-(--color-muted)">
             {t('lineHint')}
           </p>

--- a/apps/frontend/jest.config.ts
+++ b/apps/frontend/jest.config.ts
@@ -15,6 +15,8 @@ const config: Config = {
 
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
+    // renkei-next 0.4.0 exports only "import"/"types" conditions, which Jest's CJS resolver skips.
+    "^renkei-next/button$": "<rootDir>/node_modules/renkei-next/dist/button.js",
   },
   testPathIgnorePatterns: ["/node_modules/", "/dist/"],
 

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -5,7 +5,7 @@ const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
 const nextConfig: NextConfig = {
   // Needed by next/jest: msw ships ESM and must be transpiled for the Jest tests.
-  transpilePackages: ["msw", "@mswjs", "until-async"],
+  transpilePackages: ["msw", "@mswjs", "until-async", "renkei-next"],
 };
 
 export default withNextIntl(nextConfig);

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "renkei-next": "^0.4.0",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.17",
         "typescript": "^5"
@@ -8069,6 +8070,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9754,6 +9764,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/renkei-client": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/renkei-client/-/renkei-client-0.4.0.tgz",
+      "integrity": "sha512-TiMCxv/U6PCPYADTr8k6cdvLN7svPjG4mr7LWKaB1hsGRR+sf+WkyTAvNVmptyBLYM9cNCQCUw5IsPI42rmw0A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/renkei-next": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/renkei-next/-/renkei-next-0.4.0.tgz",
+      "integrity": "sha512-biKRL0AvLIpxRMhxbyHBEHEbthaWYLFZ1rOdDvhDMA7ncm4GjqTUfxc9EFeNN8AA8j/bty4C8k5vTOPH4VwBXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^6.2.10",
+        "renkei-client": "0.4.0"
+      },
+      "peerDependencies": {
+        "next": ">=15",
+        "react": ">=18"
       }
     },
     "node_modules/require-directory": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -28,6 +28,7 @@
     "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "renkei-next": "^0.4.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
     "typescript": "^5"


### PR DESCRIPTION
## Summary

Dogfoods **renkei 0.4.0**: the two LINE buttons on `/login` are now `<LineLoginButton />` from [`renkei-next`](https://www.npmjs.com/package/renkei-next), which follows [LINE's Login button design guideline](https://developers.line.biz/en/docs/line-login/login-button/) (official green, hover/press overlays, the official icon, separator, padding) instead of our generic outline `Button`. They render as real links to the backend's `/auth/line/start?role=…`, so the `onClick` + `window.location.assign` handler is gone; labels stay translated via next-intl.

## Changes
- `apps/frontend/app/login/page.tsx`: `LineLoginButton` ×2 with `href={lineLoginUrl(role)}`, stretched to the card width
- `next.config.ts`: `renkei-next` in `transpilePackages` (ESM, needed for next/jest)
- `jest.config.ts`: map `renkei-next/button` to its dist file (0.4.0 exports only `import`/`types` conditions, which Jest's CJS resolver skips — will be fixed upstream)
- login page tests: assert the links and their hrefs

## Testing
- [x] `tsc --noEmit` clean, 73 frontend tests green, `next build` OK
- [x] `/login` rendered locally (Chrome screenshot checked: two full-width LINE-green buttons with the official icon)
- [ ] Live LINE login on production after the Vercel deploy (needs a real LINE account)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRFSzDMMzucyqZyPh82YBS